### PR TITLE
Add MFA verification endpoints

### DIFF
--- a/src/Http/Controllers/MfaController.php
+++ b/src/Http/Controllers/MfaController.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Handles multi-factor authentication verification flows.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Http\Controllers
+ * @author    SwiftAuth Contributors
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Equidna\SwiftAuth\Http\Controllers;
+
+use Equidna\SwiftAuth\Contracts\UserRepositoryInterface;
+use Equidna\SwiftAuth\Facades\SwiftAuth;
+use Equidna\Toolkit\Helpers\ResponseHelper;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Finalizes MFA challenges for OTP and WebAuthn drivers.
+ */
+class MfaController extends Controller
+{
+    /**
+     * Verifies an OTP-based MFA challenge and finalizes login.
+     */
+    public function verifyOtp(
+        Request $request,
+        UserRepositoryInterface $userRepository,
+    ): JsonResponse|RedirectResponse {
+        $otp = $request->input('otp');
+
+        if (!is_string($otp) || $otp === '') {
+            return ResponseHelper::badRequest(message: 'OTP code is required.');
+        }
+
+        return $this->finalizeMfa(
+            $request,
+            $userRepository,
+            'otp',
+            ['otp' => $otp],
+        );
+    }
+
+    /**
+     * Verifies a WebAuthn-based MFA challenge and finalizes login.
+     */
+    public function verifyWebAuthn(
+        Request $request,
+        UserRepositoryInterface $userRepository,
+    ): JsonResponse|RedirectResponse {
+        $credential = $request->input('credential');
+
+        if (!is_array($credential) || $credential === []) {
+            return ResponseHelper::badRequest(message: 'WebAuthn credential is required.');
+        }
+
+        return $this->finalizeMfa(
+            $request,
+            $userRepository,
+            'webauthn',
+            ['credential' => $credential],
+        );
+    }
+
+    /**
+     * Runs the configured MFA verification flow and authenticates the user on success.
+     *
+     * @param  Request                   $request         HTTP request context.
+     * @param  UserRepositoryInterface   $userRepository  Data access for pending user lookup.
+     * @param  string                    $method          MFA method being verified (otp|webauthn).
+     * @param  array<string,mixed>       $payload         Payload forwarded to verification endpoint.
+     * @return JsonResponse|RedirectResponse              ResponseHelper-wrapped response.
+     */
+    protected function finalizeMfa(
+        Request $request,
+        UserRepositoryInterface $userRepository,
+        string $method,
+        array $payload,
+    ): JsonResponse|RedirectResponse {
+        $pendingUserId = $request->session()->get($this->pendingUserSessionKey());
+        $pendingMethod = $request->session()->get($this->pendingMethodSessionKey());
+
+        if (!$pendingUserId || ($pendingMethod && $pendingMethod !== $method)) {
+            return ResponseHelper::unauthorized(message: 'No pending MFA challenge.');
+        }
+
+        $user = $userRepository->findById((int) $pendingUserId);
+
+        if (!$user) {
+            return ResponseHelper::unauthorized(message: 'MFA user not found.');
+        }
+
+        /** @var array{verification_url?:string,driver?:string}|mixed $config */
+        $config = config("swift-auth.mfa.{$method}", []);
+        $verificationUrl = is_string($config['verification_url'] ?? null)
+            ? $config['verification_url']
+            : '';
+
+        if ($verificationUrl === '') {
+            return ResponseHelper::error(message: 'MFA verification endpoint not configured.');
+        }
+
+        $driver = is_string($config['driver'] ?? null) ? $config['driver'] : $method;
+
+        $verificationResponse = Http::asJson()->post(
+            $verificationUrl,
+            array_merge(
+                $payload,
+                [
+                    'user_id' => $user->getKey(),
+                    'method' => $method,
+                    'driver' => $driver,
+                ],
+            ),
+        );
+
+        $valid = $verificationResponse->successful()
+            && ($verificationResponse->json('valid') === true);
+
+        if (!$valid) {
+            return ResponseHelper::unauthorized(message: 'Invalid MFA verification.');
+        }
+
+        SwiftAuth::login($user);
+        $request->session()->regenerate();
+        $request->session()->forget([
+            $this->pendingUserSessionKey(),
+            $this->pendingMethodSessionKey(),
+        ]);
+
+        return ResponseHelper::success(
+            message: 'MFA verification successful.',
+            data: [
+                'user_id' => $user->getKey(),
+            ],
+            forward_url: config('swift-auth.success_url'),
+        );
+    }
+
+    /**
+     * Returns the session key that stores the pending user ID for MFA.
+     */
+    protected function pendingUserSessionKey(): string
+    {
+        return (string) config('swift-auth.mfa.pending_user_session_key', 'swift_auth_pending_user_id');
+    }
+
+    /**
+     * Returns the session key that stores the pending MFA method.
+     */
+    protected function pendingMethodSessionKey(): string
+    {
+        return (string) config('swift-auth.mfa.pending_method_session_key', 'swift_auth_pending_mfa_method');
+    }
+}

--- a/src/config/swift-auth.php
+++ b/src/config/swift-auth.php
@@ -44,6 +44,33 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Multi-Factor Authentication (MFA)
+    |--------------------------------------------------------------------------
+    |
+    | Configure how MFA challenges are verified. Each method defines the
+    | verification endpoint and driver name that will be forwarded during
+    | validation. Session keys track pending MFA state between challenge and
+    | verification.
+    |
+    */
+
+    'mfa' => [
+        'pending_user_session_key' => 'swift_auth_pending_user_id',
+        'pending_method_session_key' => 'swift_auth_pending_mfa_method',
+
+        'otp' => [
+            'verification_url' => env('SWIFT_AUTH_OTP_VERIFICATION_URL', null),
+            'driver' => env('SWIFT_AUTH_OTP_DRIVER', 'otp'),
+        ],
+
+        'webauthn' => [
+            'verification_url' => env('SWIFT_AUTH_WEBAUTHN_VERIFICATION_URL', null),
+            'driver' => env('SWIFT_AUTH_WEBAUTHN_DRIVER', 'webauthn'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Login Rate Limits
     |--------------------------------------------------------------------------
     |

--- a/src/routes/swift-auth.php
+++ b/src/routes/swift-auth.php
@@ -11,6 +11,7 @@
 use Equidna\SwiftAuth\Http\Middleware\RequireAuthentication;
 use Equidna\SwiftAuth\Http\Controllers\PasswordController;
 use Equidna\SwiftAuth\Http\Middleware\CanPerformAction;
+use Equidna\SwiftAuth\Http\Controllers\MfaController;
 use Equidna\SwiftAuth\Http\Controllers\AuthController;
 use Illuminate\Support\Facades\Route;
 
@@ -23,6 +24,15 @@ Route::middleware(['web', 'SwiftAuth.SecurityHeaders'])
         function () {
             Route::get('login', [AuthController::class, 'showLoginForm'])->name('login.form');
             Route::post('login', [AuthController::class, 'login'])->name('login');
+
+            Route::prefix('mfa')->as('mfa.')
+                ->group(
+                    function () {
+                        Route::post('otp/verify', [MfaController::class, 'verifyOtp'])->name('otp.verify');
+                        Route::post('webauthn/verify', [MfaController::class, 'verifyWebAuthn'])
+                            ->name('webauthn.verify');
+                    }
+                );
 
             Route::match(['get', 'post'], 'logout', [AuthController::class, 'logout'])->name('logout');
 

--- a/tests/Feature/Auth/MfaVerificationTest.php
+++ b/tests/Feature/Auth/MfaVerificationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Feature tests for multi-factor authentication verification flows.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Tests\Feature\Auth
+ */
+
+namespace Equidna\SwiftAuth\Tests\Feature\Auth;
+
+use Equidna\SwiftAuth\Tests\TestHelpers;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Validates MFA verification endpoints for OTP and WebAuthn drivers.
+ */
+class MfaVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+    use TestHelpers;
+
+    public function test_otp_verification_logs_in_user_on_success(): void
+    {
+        $user = $this->createTestUser();
+
+        config([
+            'swift-auth.mfa.otp.verification_url' => 'https://otp.test/verify',
+            'swift-auth.mfa.otp.driver' => 'otp-provider',
+        ]);
+
+        Http::fake([
+            'https://otp.test/verify' => Http::response(['valid' => true], 200),
+        ]);
+
+        $response = $this->withSession([
+            'swift_auth_pending_user_id' => $user->getKey(),
+            'swift_auth_pending_mfa_method' => 'otp',
+        ])->postJson('/swift-auth/mfa/otp/verify', [
+            'otp' => '123456',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.user_id', $user->getKey());
+        $this->assertAuthenticatedAs($user);
+        $this->assertFalse(session()->has('swift_auth_pending_user_id'));
+        $this->assertFalse(session()->has('swift_auth_pending_mfa_method'));
+
+        Http::assertSent(function ($request) use ($user) {
+            return $request->url() === 'https://otp.test/verify'
+                && $request['otp'] === '123456'
+                && $request['driver'] === 'otp-provider'
+                && $request['user_id'] === $user->getKey()
+                && $request['method'] === 'otp';
+        });
+    }
+
+    public function test_otp_verification_rejects_invalid_response(): void
+    {
+        $user = $this->createTestUser();
+
+        config([
+            'swift-auth.mfa.otp.verification_url' => 'https://otp.test/verify',
+        ]);
+
+        Http::fake([
+            'https://otp.test/verify' => Http::response(['valid' => false], 200),
+        ]);
+
+        $response = $this->withSession([
+            'swift_auth_pending_user_id' => $user->getKey(),
+            'swift_auth_pending_mfa_method' => 'otp',
+        ])->postJson('/swift-auth/mfa/otp/verify', [
+            'otp' => '654321',
+        ]);
+
+        $response->assertStatus(401);
+        $this->assertGuest();
+        $this->assertTrue(session()->has('swift_auth_pending_user_id'));
+    }
+
+    public function test_webauthn_verification_logs_in_user_on_success(): void
+    {
+        $user = $this->createTestUser();
+
+        config([
+            'swift-auth.mfa.webauthn.verification_url' => 'https://webauthn.test/verify',
+            'swift-auth.mfa.webauthn.driver' => 'webauthn-provider',
+        ]);
+
+        Http::fake([
+            'https://webauthn.test/verify' => Http::response(['valid' => true], 200),
+        ]);
+
+        $response = $this->withSession([
+            'swift_auth_pending_user_id' => $user->getKey(),
+            'swift_auth_pending_mfa_method' => 'webauthn',
+        ])->postJson('/swift-auth/mfa/webauthn/verify', [
+            'credential' => [
+                'id' => 'credential-id',
+                'response' => ['clientDataJSON' => 'payload'],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.user_id', $user->getKey());
+        $this->assertAuthenticatedAs($user);
+        $this->assertFalse(session()->has('swift_auth_pending_user_id'));
+        $this->assertFalse(session()->has('swift_auth_pending_mfa_method'));
+
+        Http::assertSent(function ($request) use ($user) {
+            return $request->url() === 'https://webauthn.test/verify'
+                && $request['driver'] === 'webauthn-provider'
+                && $request['user_id'] === $user->getKey()
+                && $request['method'] === 'webauthn'
+                && is_array($request['credential']);
+        });
+    }
+
+    public function test_webauthn_verification_rejects_invalid_response(): void
+    {
+        $user = $this->createTestUser();
+
+        config([
+            'swift-auth.mfa.webauthn.verification_url' => 'https://webauthn.test/verify',
+        ]);
+
+        Http::fake([
+            'https://webauthn.test/verify' => Http::response(['valid' => false], 200),
+        ]);
+
+        $response = $this->withSession([
+            'swift_auth_pending_user_id' => $user->getKey(),
+            'swift_auth_pending_mfa_method' => 'webauthn',
+        ])->postJson('/swift-auth/mfa/webauthn/verify', [
+            'credential' => [
+                'id' => 'credential-id',
+                'response' => ['clientDataJSON' => 'payload'],
+            ],
+        ]);
+
+        $response->assertStatus(401);
+        $this->assertGuest();
+        $this->assertTrue(session()->has('swift_auth_pending_user_id'));
+    }
+}


### PR DESCRIPTION
## Summary
- add an MFA controller to verify OTP and WebAuthn challenges via configured drivers
- register MFA verification routes and configuration keys for pending sessions
- add feature coverage for successful and invalid MFA verification flows

## Testing
- not run (composer install failed because GitHub downloads were blocked)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f01036fb08322b72a3e0c2ecdbec3)