### PR TITLE
Add remember-me token metadata validation

### DIFF
--- a/src/DTO/RememberToken.php
+++ b/src/DTO/RememberToken.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Value object representing a persisted remember-me token with metadata.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\DTO
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Equidna\SwiftAuth\DTO;
+
+/**
+ * Immutable token details used for remember-me validation.
+ */
+class RememberToken
+{
+    /**
+     * @param  string       $token       Raw token value (already persisted).
+     * @param  string|null  $ipAddress   IP address recorded when the token was created.
+     * @param  string|null  $userAgent   User agent recorded when the token was created.
+     * @param  string|null  $deviceName  Optional device identifier/header recorded with the token.
+     * @param  int|null     $userId      Optional associated user ID for logging.
+     */
+    public function __construct(
+        public readonly string $token,
+        public readonly ?string $ipAddress = null,
+        public readonly ?string $userAgent = null,
+        public readonly ?string $deviceName = null,
+        public readonly ?int $userId = null,
+    ) {
+    }
+}

--- a/src/Services/RememberMeService.php
+++ b/src/Services/RememberMeService.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Implements remember-me token validation with device and network awareness.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Services
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Services;
+
+use Equidna\SwiftAuth\DTO\RememberToken;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Validates remember-me login attempts against stored token metadata.
+ */
+class RememberMeService
+{
+    /**
+     * Validates an incoming remember-me request against the stored token metadata.
+     *
+     * @param  Request       $request  Incoming HTTP request.
+     * @param  RememberToken $token    Persisted token metadata.
+     * @return bool                    True if the request matches the configured policy.
+     */
+    public function attemptRememberLogin(Request $request, RememberToken $token): bool
+    {
+        $config = config('swift-auth.remember_me', []);
+
+        $policy = is_string($config['policy'] ?? null)
+            ? strtolower((string) $config['policy'])
+            : 'strict';
+
+        $allowSubnet = (bool) ($config['allow_same_subnet'] ?? false);
+        $subnetMask = (int) ($config['subnet_mask'] ?? 24);
+        $deviceHeader = $config['device_header'] ?? 'X-Device-Id';
+        $requireDeviceHeader = (bool) ($config['require_device_header'] ?? false);
+
+        $requestIp = (string) ($request->ip() ?? '');
+        $requestUserAgent = (string) ($request->userAgent() ?? '');
+        $requestDevice = $deviceHeader ? (string) ($request->header($deviceHeader) ?? '') : '';
+
+        $ipMatch = $this->ipMatches($token->ipAddress, $requestIp, $allowSubnet, $subnetMask);
+        $userAgentMatch = $this->stringsMatch($token->userAgent, $requestUserAgent);
+        $deviceMatch = $this->deviceMatches($token->deviceName, $requestDevice, $requireDeviceHeader);
+
+        $matches = [
+            'ip' => $ipMatch,
+            'user_agent' => $userAgentMatch,
+            'device' => $deviceMatch,
+        ];
+
+        $accepted = $policy === 'lenient'
+            ? $this->passesLenientPolicy($matches)
+            : $this->passesStrictPolicy($matches);
+
+        if (!$accepted) {
+            $this->logMismatch(
+                policy: $policy,
+                requestIp: $requestIp,
+                tokenIp: $token->ipAddress,
+                requestUserAgent: $requestUserAgent,
+                tokenUserAgent: $token->userAgent,
+                requestDevice: $requestDevice,
+                tokenDevice: $token->deviceName,
+                userId: $token->userId,
+                matches: $matches,
+            );
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * Evaluates strict policy: all attributes must match.
+     */
+    private function passesStrictPolicy(array $matches): bool
+    {
+        return $matches['ip'] && $matches['user_agent'] && $matches['device'];
+    }
+
+    /**
+     * Evaluates lenient policy: IP must match and either user agent or device matches.
+     */
+    private function passesLenientPolicy(array $matches): bool
+    {
+        return $matches['ip'] && ($matches['user_agent'] || $matches['device']);
+    }
+
+    /**
+     * Compares two string values using a case-sensitive comparison.
+     */
+    private function stringsMatch(?string $expected, ?string $actual): bool
+    {
+        return isset($expected, $actual) && strcmp($expected, $actual) === 0;
+    }
+
+    /**
+     * Determines if device headers match or are optional.
+     */
+    private function deviceMatches(?string $expectedDevice, string $actualDevice, bool $requireDeviceHeader): bool
+    {
+        if (!$requireDeviceHeader && ($expectedDevice === null || $expectedDevice === '')) {
+            return true;
+        }
+
+        return $expectedDevice !== null
+            && $expectedDevice !== ''
+            && $actualDevice !== ''
+            && strcmp($expectedDevice, $actualDevice) === 0;
+    }
+
+    /**
+     * Compares IP addresses with optional subnet tolerance.
+     */
+    private function ipMatches(?string $expectedIp, string $actualIp, bool $allowSubnet, int $subnetMask): bool
+    {
+        if (!$expectedIp || !$actualIp) {
+            return false;
+        }
+
+        if ($expectedIp === $actualIp) {
+            return true;
+        }
+
+        if (!$allowSubnet) {
+            return false;
+        }
+
+        return $this->inSameSubnet($expectedIp, $actualIp, $subnetMask);
+    }
+
+    /**
+     * Determines if two IP addresses share the same subnet using the provided mask.
+     */
+    private function inSameSubnet(string $ipA, string $ipB, int $mask): bool
+    {
+        $packedA = @inet_pton($ipA);
+        $packedB = @inet_pton($ipB);
+
+        if ($packedA === false || $packedB === false || strlen($packedA) !== strlen($packedB)) {
+            return false;
+        }
+
+        $bytes = intdiv($mask, 8);
+        $remainingBits = $mask % 8;
+
+        if ($bytes > 0 && substr($packedA, 0, $bytes) !== substr($packedB, 0, $bytes)) {
+            return false;
+        }
+
+        if ($remainingBits === 0) {
+            return true;
+        }
+
+        $maskByte = chr((0xFF << (8 - $remainingBits)) & 0xFF);
+
+        return (ord($packedA[$bytes]) & ord($maskByte)) === (ord($packedB[$bytes]) & ord($maskByte));
+    }
+
+    /**
+     * Logs structured mismatch details for auditing.
+     */
+    private function logMismatch(
+        string $policy,
+        string $requestIp,
+        ?string $tokenIp,
+        string $requestUserAgent,
+        ?string $tokenUserAgent,
+        string $requestDevice,
+        ?string $tokenDevice,
+        ?int $userId,
+        array $matches,
+    ): void {
+        $mismatched = array_keys(array_filter($matches, fn (bool $match) => !$match));
+
+        Log::warning('swift-auth.remember_me.mismatch', [
+            'policy' => $policy,
+            'mismatched_fields' => $mismatched,
+            'request' => [
+                'ip' => $requestIp,
+                'user_agent' => $requestUserAgent,
+                'device' => $requestDevice,
+            ],
+            'token' => [
+                'ip' => $tokenIp,
+                'user_agent' => $tokenUserAgent,
+                'device' => $tokenDevice,
+                'user_id' => $userId,
+            ],
+        ]);
+    }
+}

--- a/src/config/swift-auth.php
+++ b/src/config/swift-auth.php
@@ -173,6 +173,26 @@ return [
     'actions' => [
         'sw-admin' => 'Swift Auth admin', // !! DO NOT REMOVE THIS ACTION: used in core SwiftAuth functions
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remember Me Token Matching
+    |--------------------------------------------------------------------------
+    |
+    | Controls how persisted remember-me tokens are validated against incoming
+    | requests. Strict policy requires IP, user agent and device (when present)
+    | to match exactly. Lenient policy allows IP subnet tolerance and accepts a
+    | match when either user agent or device aligns.
+    |
+    */
+
+    'remember_me' => [
+        'policy' => env('SWIFT_AUTH_REMEMBER_POLICY', 'strict'), // strict|lenient
+        'allow_same_subnet' => env('SWIFT_AUTH_REMEMBER_ALLOW_SUBNET', true),
+        'subnet_mask' => env('SWIFT_AUTH_REMEMBER_SUBNET_MASK', 24),
+        'device_header' => env('SWIFT_AUTH_REMEMBER_DEVICE_HEADER', 'X-Device-Id'),
+        'require_device_header' => env('SWIFT_AUTH_REMEMBER_REQUIRE_DEVICE', false),
+    ],
     /*
     |--------------------------------------------------------------------------
     | Table & Route Prefix

--- a/tests/Unit/RememberMeServiceTest.php
+++ b/tests/Unit/RememberMeServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Unit tests for remember-me metadata validation.
+ */
+
+namespace Equidna\SwiftAuth\Tests\Unit;
+
+use Equidna\SwiftAuth\DTO\RememberToken;
+use Equidna\SwiftAuth\Services\RememberMeService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class RememberMeServiceTest extends TestCase
+{
+    /** @var RememberMeService */
+    private RememberMeService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RememberMeService();
+        Log::fake();
+    }
+
+    public function test_strict_policy_requires_exact_matches(): void
+    {
+        config()->set('swift-auth.remember_me', [
+            'policy' => 'strict',
+            'allow_same_subnet' => false,
+            'device_header' => 'X-Device-Id',
+            'require_device_header' => true,
+        ]);
+
+        $token = new RememberToken(
+            token: 'abc',
+            ipAddress: '192.168.10.5',
+            userAgent: 'Test UA',
+            deviceName: 'laptop-01',
+            userId: 42,
+        );
+
+        $request = Request::create('/', 'GET', server: [
+            'REMOTE_ADDR' => '192.168.10.5',
+            'HTTP_USER_AGENT' => 'Test UA',
+            'HTTP_X_DEVICE_ID' => 'laptop-01',
+        ]);
+
+        $this->assertTrue($this->service->attemptRememberLogin($request, $token));
+        Log::assertNothingLogged();
+    }
+
+    public function test_subnet_match_is_allowed_in_lenient_policy(): void
+    {
+        config()->set('swift-auth.remember_me', [
+            'policy' => 'lenient',
+            'allow_same_subnet' => true,
+            'subnet_mask' => 24,
+            'require_device_header' => false,
+            'device_header' => 'X-Device-Id',
+        ]);
+
+        $token = new RememberToken(
+            token: 'abc',
+            ipAddress: '10.0.0.10',
+            userAgent: 'Browser A',
+            deviceName: null,
+        );
+
+        $request = Request::create('/', 'GET', server: [
+            'REMOTE_ADDR' => '10.0.0.55',
+            'HTTP_USER_AGENT' => 'Browser A',
+        ]);
+
+        $this->assertTrue($this->service->attemptRememberLogin($request, $token));
+        Log::assertNothingLogged();
+    }
+
+    public function test_mismatched_metadata_logs_structured_entry(): void
+    {
+        config()->set('swift-auth.remember_me', [
+            'policy' => 'strict',
+            'allow_same_subnet' => false,
+            'require_device_header' => true,
+            'device_header' => 'X-Device-Id',
+        ]);
+
+        $token = new RememberToken(
+            token: 'abc',
+            ipAddress: '10.0.0.1',
+            userAgent: 'Browser A',
+            deviceName: 'laptop-01',
+            userId: 99,
+        );
+
+        $request = Request::create('/', 'GET', server: [
+            'REMOTE_ADDR' => '10.0.1.5',
+            'HTTP_USER_AGENT' => 'Browser B',
+            'HTTP_X_DEVICE_ID' => 'tablet-02',
+        ]);
+
+        $this->assertFalse($this->service->attemptRememberLogin($request, $token));
+
+        Log::assertLogged('warning', function ($message, array $context) {
+            return $message === 'swift-auth.remember_me.mismatch'
+                && in_array('ip', $context['mismatched_fields'], true)
+                && in_array('user_agent', $context['mismatched_fields'], true)
+                && in_array('device', $context['mismatched_fields'], true)
+                && $context['token']['user_id'] === 99
+                && $context['request']['ip'] === '10.0.1.5'
+                && $context['token']['ip'] === '10.0.0.1';
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a remember token value object and a service to validate remember-me logins against stored metadata
- introduce remember_me configuration toggles for policy selection, subnet tolerance, and device headers
- cover strict/lenient acceptance paths and mismatch logging with new unit tests

## Testing
- composer install --no-interaction *(fails: ext-sodium missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f00fad0908322888c019b576d2fbc)