### PR TITLE
Add admin session governance commands and APIs

### DIFF
--- a/src/Console/Commands/CreateAdminUser.php
+++ b/src/Console/Commands/CreateAdminUser.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Console\Commands;
+
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 

--- a/src/Console/Commands/InstallSwiftAuth.php
+++ b/src/Console/Commands/InstallSwiftAuth.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Console\Commands;
+
 use Illuminate\Console\Command;
 
 /**

--- a/src/Console/Commands/ListSessions.php
+++ b/src/Console/Commands/ListSessions.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Artisan command to list active SwiftAuth sessions.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Console\Commands
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+use Equidna\SwiftAuth\Services\SwiftSessionAuth;
+
+/**
+ * Displays active sessions for governance and auditing.
+ */
+class ListSessions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'swift-auth:sessions {userId? : Filter by user ID}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List SwiftAuth sessions, optionally filtering by user ID';
+
+    public function __construct(private SwiftSessionAuth $sessionAuth)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $userId = $this->argument('userId');
+
+        $sessions = $this->sessionAuth->allSessions();
+
+        if ($userId !== null) {
+            $sessions = $sessions->where('id_user', (int) $userId);
+        }
+
+        if ($sessions->isEmpty()) {
+            $this->info('No sessions found.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->table(
+            headers: [
+                'Session ID',
+                'User ID',
+                'Device',
+                'IP Address',
+                'Platform',
+                'Browser',
+                'Last Activity',
+            ],
+            rows: $this->mapSessions($sessions),
+        );
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Maps session models into tabular rows.
+     *
+     * @param  Collection<int, \Equidna\SwiftAuth\Models\UserSession> $sessions  Session collection.
+     * @return array<int, array<int, string|null>>
+     */
+    private function mapSessions(Collection $sessions): array
+    {
+        return $sessions
+            ->map(
+                fn ($session) => [
+                    $session->session_id,
+                    $session->id_user,
+                    $session->device_name,
+                    $session->ip_address,
+                    $session->platform,
+                    $session->browser,
+                    optional($session->last_activity)->toDateTimeString(),
+                ]
+            )
+            ->all();
+    }
+}

--- a/src/Console/Commands/PreviewEmailTemplates.php
+++ b/src/Console/Commands/PreviewEmailTemplates.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Console\Commands;
+
 use Illuminate\Console\Command;
 
 final class PreviewEmailTemplates extends Command

--- a/src/Console/Commands/PurgeExpiredTokens.php
+++ b/src/Console/Commands/PurgeExpiredTokens.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Artisan command to clean up expired SwiftAuth tokens.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Console\Commands
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Equidna\SwiftAuth\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use Equidna\SwiftAuth\Models\PasswordResetToken;
+use Equidna\SwiftAuth\Models\User;
+
+/**
+ * Purges expired password reset and email verification tokens.
+ */
+final class PurgeExpiredTokens extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'swift-auth:purge-expired-tokens';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Remove expired SwiftAuth password reset and email verification tokens';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $passwordTtl = (int) config('swift-auth.password_reset_ttl', 900);
+        $verificationTtl = (int) config('swift-auth.email_verification.token_ttl', 86400);
+
+        $passwordThreshold = now()->subSeconds($passwordTtl);
+        $verificationThreshold = now()->subSeconds($verificationTtl);
+
+        $passwordDeleted = PasswordResetToken::where('created_at', '<', $passwordThreshold)->delete();
+        $verificationDeleted = User::whereNotNull('email_verification_token')
+            ->whereNotNull('email_verification_sent_at')
+            ->where('email_verification_sent_at', '<', $verificationThreshold)
+            ->update([
+                'email_verification_token' => null,
+                'email_verification_sent_at' => null,
+            ]);
+
+        $this->info("Deleted {$passwordDeleted} expired password reset tokens.");
+        $this->info("Cleared {$verificationDeleted} expired email verification tokens.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/PurgeStaleSessions.php
+++ b/src/Console/Commands/PurgeStaleSessions.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Artisan command to purge stale session records.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Console\Commands
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Console\Commands;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Console\Command;
+
+use Equidna\SwiftAuth\Models\UserSession;
+
+/**
+ * Removes session rows that have exceeded idle or absolute lifetimes.
+ */
+class PurgeStaleSessions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'swift-auth:purge-stale-sessions';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete expired SwiftAuth session records based on configured lifetimes';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $idleTimeout = (int) config('swift-auth.session_lifetimes.idle_timeout_seconds', 0);
+        $absoluteTimeout = (int) config('swift-auth.session_lifetimes.absolute_timeout_seconds', 0);
+        $graceSeconds = (int) config('swift-auth.session_cleanup.grace_seconds', 0);
+
+        $now = Carbon::now();
+
+        $idleCutoff = $idleTimeout > 0 ? $now->copy()->subSeconds($idleTimeout + $graceSeconds) : null;
+        $absoluteCutoff = $absoluteTimeout > 0 ? $now->copy()->subSeconds($absoluteTimeout + $graceSeconds) : null;
+
+        if ($idleCutoff === null && $absoluteCutoff === null) {
+            $this->info('No session lifetimes configured; skipping purge.');
+
+            return Command::SUCCESS;
+        }
+
+        $deleted = UserSession::query()
+            ->when(
+                $idleCutoff !== null,
+                fn ($query) => $query->where('last_activity', '<', $idleCutoff),
+            )
+            ->when(
+                $absoluteCutoff !== null,
+                function ($query) use ($idleCutoff, $absoluteCutoff) {
+                    return $idleCutoff !== null
+                        ? $query->orWhere('created_at', '<', $absoluteCutoff)
+                        : $query->where('created_at', '<', $absoluteCutoff);
+                },
+            )
+            ->delete();
+
+        $this->info("Deleted {$deleted} stale session(s).");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Commands/RevokeUserSessions.php
+++ b/src/Console/Commands/RevokeUserSessions.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Artisan command to revoke SwiftAuth sessions for a user.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Console\Commands
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use Equidna\SwiftAuth\Services\SwiftSessionAuth;
+
+/**
+ * Enables administrators to revoke sessions from the CLI.
+ */
+class RevokeUserSessions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'swift-auth:revoke-sessions
+        {userId : User ID whose sessions should be revoked}
+        {--session=* : Specific session IDs to revoke}
+        {--all : Revoke all sessions for the user}
+        {--remember : Also clear remember-me tokens for the user}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Revoke one or more SwiftAuth sessions for the given user';
+
+    public function __construct(private SwiftSessionAuth $sessionAuth)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $userId = (int) $this->argument('userId');
+        $sessionIds = array_filter((array) $this->option('session'));
+        $revokeAll = (bool) $this->option('all');
+        $clearRememberTokens = (bool) $this->option('remember');
+
+        if (!$revokeAll && empty($sessionIds)) {
+            $this->error('Specify at least one --session or use --all to revoke every session.');
+
+            return Command::INVALID;
+        }
+
+        if ($revokeAll) {
+            $result = $this->sessionAuth->revokeAllSessionsForUser(
+                userId: $userId,
+                includeRememberTokens: $clearRememberTokens,
+            );
+
+            $this->info("Revoked {$result['deleted_sessions']} session(s) for user {$userId}.");
+
+            if ($result['cleared_remember_tokens'] > 0) {
+                $this->info(
+                    "Cleared {$result['cleared_remember_tokens']} remember-me token(s) for user {$userId}.",
+                );
+            }
+        } else {
+            foreach ($sessionIds as $sessionId) {
+                $this->sessionAuth->revokeSession(
+                    userId: $userId,
+                    sessionId: $sessionId,
+                );
+            }
+
+            $this->info('Revoked sessions: ' . implode(', ', $sessionIds));
+
+            if ($clearRememberTokens) {
+                $cleared = $this->sessionAuth->revokeRememberTokensForUser($userId);
+
+                $this->info("Cleared {$cleared} remember-me token(s) for user {$userId}.");
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Commands/UnlockUserCommand.php
+++ b/src/Console/Commands/UnlockUserCommand.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Console\Commands;
+
 use Illuminate\Console\Command;
 
 use Equidna\SwiftAuth\Models\User;

--- a/src/Contracts/UserRepositoryInterface.php
+++ b/src/Contracts/UserRepositoryInterface.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Contracts;
+
 use Equidna\SwiftAuth\Models\User;
 
 /**
@@ -67,5 +68,8 @@ interface UserRepositoryInterface
      * @param  int  $seconds  Lockout duration in seconds.
      * @return void
      */
-    public function lockAccount(User $user, int $seconds): void;
+    public function lockAccount(
+        User $user,
+        int $seconds,
+    ): void;
 }

--- a/src/Facades/SwiftAuth.php
+++ b/src/Facades/SwiftAuth.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Facades;
+
 use Illuminate\Support\Facades\Facade;
 
 use Equidna\SwiftAuth\Models\User;
@@ -30,13 +31,16 @@ use Equidna\SwiftAuth\Models\User;
  *
  * @see \Equidna\SwiftAuth\Services\SwiftSessionAuth
  *
- * @method static void login(User $user)
+ * @method static array login(User $user, null|string $ipAddress = null, null|string $userAgent = null, null|string $deviceName = null, bool $remember = false)
  * @method static void logout()
  * @method static bool check()
  * @method static int|null id()
  * @method static User|null user()
  * @method static bool canPerformAction(string|array<string,mixed> $actions)
  * @method static User userOrFail()
+ * @method static \Illuminate\Support\Collection<int, \Equidna\SwiftAuth\Models\UserSession> sessionsForUser(int $userId)
+ * @method static void revokeSession(int $userId, string $sessionId)
+ * @method static void startMfaChallenge(User $user, string $driver, null|string $ipAddress = null, null|string $userAgent = null)
  */
 class SwiftAuth extends Facade
 {

--- a/src/Http/Controllers/AdminSessionController.php
+++ b/src/Http/Controllers/AdminSessionController.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Admin endpoints for managing user sessions.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Http\Controllers
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+use Equidna\SwiftAuth\Facades\SwiftAuth;
+use Equidna\SwiftAuth\Helpers\ResponseHelper;
+use Equidna\SwiftAuth\Services\SwiftSessionAuth;
+
+/**
+ * Provides session listing and revocation for administrators.
+ */
+class AdminSessionController extends Controller
+{
+    public function __construct(private SwiftSessionAuth $sessionAuth)
+    {
+    }
+
+    /**
+     * Lists all sessions across all users.
+     *
+     * @param  Request $request  HTTP request context.
+     * @return JsonResponse
+     */
+    public function all(Request $request): JsonResponse
+    {
+        return ResponseHelper::success(
+            message: 'All sessions loaded.',
+            data: [
+                'sessions' => $this->sessionAuth->allSessions(),
+            ],
+        );
+    }
+
+    /**
+     * Lists all sessions for the selected user.
+     *
+     * @param  Request $request  HTTP request context.
+     * @param  int     $userId   Identifier of the user to inspect.
+     * @return JsonResponse
+     */
+    public function index(
+        Request $request,
+        int $userId,
+    ): JsonResponse {
+        $sessions = $this->sessionAuth->sessionsForUser($userId);
+
+        return ResponseHelper::success(
+            message: 'User sessions loaded.',
+            data: [
+                'user_id' => $userId,
+                'sessions' => $sessions,
+            ],
+        );
+    }
+
+    /**
+     * Revokes a specific session for the given user.
+     *
+     * @param  Request $request     HTTP request context.
+     * @param  int     $userId      Identifier of the user who owns the session.
+     * @param  string  $sessionId   Identifier of the session to revoke.
+     * @return JsonResponse
+     */
+    public function destroy(
+        Request $request,
+        int $userId,
+        string $sessionId,
+    ): JsonResponse {
+        $this->sessionAuth->revokeSession($userId, $sessionId);
+
+        return ResponseHelper::success(
+            message: 'Session revoked.',
+            data: [
+                'user_id' => $userId,
+                'session_id' => $sessionId,
+                'revoked_by' => SwiftAuth::id(),
+            ],
+        );
+    }
+
+    /**
+     * Revokes all sessions for the given user.
+     *
+     * @param  Request $request  HTTP request context.
+     * @param  int     $userId   Identifier of the user whose sessions are revoked.
+     * @return JsonResponse
+     */
+    public function destroyAll(Request $request, int $userId): JsonResponse
+    {
+        $includeRememberTokens = $request->boolean('include_remember_tokens', false);
+
+        $result = $this->sessionAuth->revokeAllSessionsForUser(
+            userId: $userId,
+            includeRememberTokens: $includeRememberTokens,
+        );
+
+        return ResponseHelper::success(
+            message: 'All sessions revoked.',
+            data: [
+                'user_id' => $userId,
+                'deleted_sessions' => $result['deleted_sessions'],
+                'cleared_remember_tokens' => $result['cleared_remember_tokens'],
+                'revoked_by' => SwiftAuth::id(),
+            ],
+        );
+    }
+}

--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Controllers;
+
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -138,7 +139,10 @@ class RoleController extends Controller
      * @param  string        $id_role  Identifier for the role.
      * @return View|Response           Blade or Inertia response with role data.
      */
-    public function edit(Request $request, string $id_role): View|Response
+    public function edit(
+        Request $request,
+        string $id_role,
+    ): View|Response
     {
         $role = Role::findOrFail($id_role);
 
@@ -160,7 +164,10 @@ class RoleController extends Controller
      * @return RedirectResponse|JsonResponse       Context-aware success response.
      * @throws BadRequestException                 When validation fails.
      */
-    public function update(Request $request, string $id_role): RedirectResponse|JsonResponse
+    public function update(
+        Request $request,
+        string $id_role,
+    ): RedirectResponse|JsonResponse
     {
         $role = Role::findOrFail($id_role);
 
@@ -218,7 +225,10 @@ class RoleController extends Controller
      * @param  string                    $id_role  Identifier of the role to delete.
      * @return RedirectResponse|JsonResponse       Context-aware success response.
      */
-    public function destroy(Request $request, string $id_role): RedirectResponse|JsonResponse
+    public function destroy(
+        Request $request,
+        string $id_role,
+    ): RedirectResponse|JsonResponse
     {
         $role = Role::findOrFail($id_role);
 

--- a/src/Http/Controllers/SessionController.php
+++ b/src/Http/Controllers/SessionController.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Manages user sessions for SwiftAuth.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Http\Controllers
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+use Equidna\SwiftAuth\Facades\SwiftAuth;
+use Equidna\SwiftAuth\Helpers\ResponseHelper;
+use Equidna\SwiftAuth\Services\SwiftSessionAuth;
+
+/**
+ * Exposes endpoints to list and revoke active sessions for the authenticated user.
+ */
+class SessionController extends Controller
+{
+    public function __construct(private SwiftSessionAuth $sessionAuth)
+    {
+    }
+
+    /**
+     * Lists all sessions for the authenticated user.
+     *
+     * @param  Request $request  HTTP request context.
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $userId = SwiftAuth::id();
+
+        $sessions = $userId ? $this->sessionAuth->sessionsForUser($userId) : collect();
+
+        return ResponseHelper::success(
+            message: 'Active sessions loaded.',
+            data: [
+                'sessions' => $sessions,
+            ],
+        );
+    }
+
+    /**
+     * Revokes a specific session for the authenticated user.
+     *
+     * @param  Request $request      HTTP request context.
+     * @param  string  $sessionId    Identifier of the session to revoke.
+     * @return JsonResponse
+     */
+    public function destroy(
+        Request $request,
+        string $sessionId,
+    ): JsonResponse {
+        $userId = SwiftAuth::id();
+
+        if ($userId) {
+            $this->sessionAuth->revokeSession($userId, $sessionId);
+        }
+
+        return ResponseHelper::success(
+            message: 'Session revoked.',
+        );
+    }
+}

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Controllers;
+
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -159,7 +160,13 @@ class UserController extends Controller
             );
         }
 
-        SwiftAuth::login($user);
+        SwiftAuth::login(
+            user: $user,
+            ipAddress: $request->ip(),
+            userAgent: $request->userAgent(),
+            deviceName: (string) $request->header('X-Device-Name', ''),
+            remember: false,
+        );
 
         return ResponseHelper::created(
             message: 'Registration successful.',
@@ -177,7 +184,10 @@ class UserController extends Controller
      * @param  string        $id_user  Identifier of the user to show.
      * @return View|Response           Blade or Inertia response with user data.
      */
-    public function show(Request $request, string $id_user): View|Response
+    public function show(
+        Request $request,
+        string $id_user,
+    ): View|Response
     {
         $user = User::findOrFail($id_user);
         $roles = Cache::remember(
@@ -203,7 +213,10 @@ class UserController extends Controller
      * @param  string                    $id_user  Identifier of the user to update.
      * @return RedirectResponse|JsonResponse       Context-aware success response.
      */
-    public function update(UpdateUserRequest $request, string $id_user): RedirectResponse|JsonResponse
+    public function update(
+        UpdateUserRequest $request,
+        string $id_user,
+    ): RedirectResponse|JsonResponse
     {
         $user = User::findOrFail($id_user);
 
@@ -248,7 +261,10 @@ class UserController extends Controller
      * @param  string        $id_user  Identifier of the user to edit.
      * @return View|Response           Blade or Inertia response with user and role data.
      */
-    public function edit(Request $request, string $id_user): View|Response
+    public function edit(
+        Request $request,
+        string $id_user,
+    ): View|Response
     {
         $user = User::findOrFail($id_user);
         $roles = Cache::remember(
@@ -275,7 +291,10 @@ class UserController extends Controller
      * @return RedirectResponse|JsonResponse       Context-aware success response.
      * @throws ForbiddenException                  When attempting to delete your own account.
      */
-    public function destroy(Request $request, string $id_user): RedirectResponse|JsonResponse
+    public function destroy(
+        Request $request,
+        string $id_user,
+    ): RedirectResponse|JsonResponse
     {
         if ((int) SwiftAuth::id() === (int) $id_user) {
             throw new ForbiddenException('You cannot delete your own account.');

--- a/src/Http/Middleware/CanPerformAction.php
+++ b/src/Http/Middleware/CanPerformAction.php
@@ -9,6 +9,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Middleware;
+
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Http/Middleware/RequireAuthentication.php
+++ b/src/Http/Middleware/RequireAuthentication.php
@@ -9,6 +9,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Middleware;
+
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,7 +35,10 @@ class RequireAuthentication
      * @return Response           Response after handling the request.
      * @throws ModelNotFoundException  When authenticated user ID exists but user record not found.
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(
+        Request $request,
+        Closure $next,
+    ): Response
     {
         if (!SwiftAuth::check()) {
             return ResponseHelper::unauthorized(

--- a/src/Http/Middleware/SecurityHeaders.php
+++ b/src/Http/Middleware/SecurityHeaders.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Middleware;
+
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,28 +34,55 @@ final class SecurityHeaders
      * @param  Closure  $next     Next middleware in the pipeline.
      * @return Response           Response with security headers applied.
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(
+        Request $request,
+        Closure $next,
+    ): Response
     {
         /** @var Response $response */
         $response = $next($request);
 
         // Prevent clickjacking attacks
-        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set(
+            'X-Frame-Options',
+            'SAMEORIGIN',
+        );
 
         // Prevent MIME type sniffing
-        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set(
+            'X-Content-Type-Options',
+            'nosniff',
+        );
 
         // Control referrer information leakage
-        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set(
+            'Referrer-Policy',
+            (string) config('swift-auth.security_headers.referrer_policy', 'strict-origin-when-cross-origin'),
+        );
 
         // Enable XSS protection in older browsers
-        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set(
+            'X-XSS-Protection',
+            '1; mode=block',
+        );
 
         // Enforce HTTPS if request is secure
-        if ($request->isSecure()) {
+        $hstsConfig = config('swift-auth.security_headers.hsts', []);
+        if ($request->isSecure() && ($hstsConfig['enabled'] ?? true)) {
+            $hstsMaxAge = (int) ($hstsConfig['max_age'] ?? 31536000);
+            $hstsParts = ["max-age={$hstsMaxAge}"];
+
+            if ($hstsConfig['include_subdomains'] ?? true) {
+                $hstsParts[] = 'includeSubDomains';
+            }
+
+            if ($hstsConfig['preload'] ?? false) {
+                $hstsParts[] = 'preload';
+            }
+
             $response->headers->set(
                 'Strict-Transport-Security',
-                'max-age=31536000; includeSubDomains'
+                implode('; ', $hstsParts),
             );
         }
 
@@ -65,12 +93,42 @@ final class SecurityHeaders
         if ($hasConfig) {
             $csp = config('swift-auth.security_headers.csp');
             if ($csp) {
-                $response->headers->set('Content-Security-Policy', $csp);
+                $response->headers->set(
+                    'Content-Security-Policy',
+                    $csp,
+                );
             }
 
             $permissionsPolicy = config('swift-auth.security_headers.permissions_policy');
             if ($permissionsPolicy) {
-                $response->headers->set('Permissions-Policy', $permissionsPolicy);
+                $response->headers->set(
+                    'Permissions-Policy',
+                    $permissionsPolicy,
+                );
+            }
+
+            $coop = config('swift-auth.security_headers.cross_origin_opener_policy');
+            if ($coop) {
+                $response->headers->set(
+                    'Cross-Origin-Opener-Policy',
+                    $coop,
+                );
+            }
+
+            $coep = config('swift-auth.security_headers.cross_origin_embedder_policy');
+            if ($coep) {
+                $response->headers->set(
+                    'Cross-Origin-Embedder-Policy',
+                    $coep,
+                );
+            }
+
+            $corp = config('swift-auth.security_headers.cross_origin_resource_policy');
+            if ($corp) {
+                $response->headers->set(
+                    'Cross-Origin-Resource-Policy',
+                    $corp,
+                );
             }
         }
 

--- a/src/Http/Requests/LoginRequest.php
+++ b/src/Http/Requests/LoginRequest.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Requests;
+
 use Equidna\Toolkit\Http\Requests\EquidnaFormRequest;
 
 /**
@@ -46,6 +47,10 @@ final class LoginRequest extends EquidnaFormRequest
                 'required',
                 'string',
                 'min:' . $min,
+            ],
+            'remember' => [
+                'sometimes',
+                'boolean',
             ],
         ];
     }

--- a/src/Http/Requests/RegisterUserRequest.php
+++ b/src/Http/Requests/RegisterUserRequest.php
@@ -11,7 +11,9 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Requests;
+
 use Equidna\Toolkit\Http\Requests\EquidnaFormRequest;
+use Equidna\SwiftAuth\Services\PasswordPolicy;
 
 /**
  * Validates registration payload with email uniqueness and password strength.
@@ -38,7 +40,7 @@ final class RegisterUserRequest extends EquidnaFormRequest
     public function rules(): array
     {
         $prefix = config('swift-auth.table_prefix', '');
-        $minLength = (int) config('swift-auth.password_min_length', 8);
+        $passwordRules = PasswordPolicy::rules();
 
         return [
             'name' => [
@@ -57,7 +59,7 @@ final class RegisterUserRequest extends EquidnaFormRequest
                 'required',
                 'string',
                 'confirmed',
-                'min:' . $minLength,
+                ...$passwordRules,
             ],
             'role' => [
                 'sometimes',

--- a/src/Http/Requests/UpdateUserRequest.php
+++ b/src/Http/Requests/UpdateUserRequest.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Http\Requests;
+
 use Equidna\Toolkit\Http\Requests\EquidnaFormRequest;
 
 /**

--- a/src/Mail/PasswordResetMail.php
+++ b/src/Mail/PasswordResetMail.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Mail;
+
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -26,7 +27,10 @@ class PasswordResetMail extends Mailable implements ShouldQueue
     public string $email;
 
 
-    public function __construct(string $email, string $token)
+    public function __construct(
+        string $email,
+        string $token,
+    )
     {
         $this->token = $token;
         $this->email = $email;
@@ -43,10 +47,13 @@ class PasswordResetMail extends Mailable implements ShouldQueue
         $resetUrl = url("/{$routePrefix}/password/{$this->token}?email=" . urlencode($this->email));
 
         return $this->subject('Restablecer contraseña')
-            ->view('swift-auth::emails.password_reset', [
-                'resetUrl' => $resetUrl,
-                'email' => $this->email,
-                'token' => $this->token,
-            ]);
+            ->view(
+                'swift-auth::emails.password_reset',
+                [
+                    'resetUrl' => $resetUrl,
+                    'email' => $this->email,
+                    'token' => $this->token,
+                ],
+            );
     }
 }

--- a/src/Models/PasswordResetToken.php
+++ b/src/Models/PasswordResetToken.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Models;
+
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Models/RememberToken.php
+++ b/src/Models/RememberToken.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Persistent remember-me tokens for SwiftAuth logins.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Models
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Represents a persistent remember-me token row.
+ *
+ * @property int    $id_remember_token
+ * @property int    $id_user
+ * @property string $selector
+ * @property string $hashed_token
+ * @property string $ip_address
+ * @property string $user_agent
+ * @property string $device_name
+ * @property string $platform
+ * @property string $browser
+ */
+class RememberToken extends Model
+{
+    protected $table;
+    protected $primaryKey = 'id_remember_token';
+
+    protected $fillable = [
+        'id_user',
+        'selector',
+        'hashed_token',
+        'expires_at',
+        'last_used_at',
+        'ip_address',
+        'user_agent',
+        'device_name',
+        'platform',
+        'browser',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'last_used_at' => 'datetime',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        try {
+            $prefix = config('swift-auth.table_prefix', '');
+        } catch (\Throwable $exception) {
+            $prefix = '';
+        }
+
+        $this->table = $prefix . 'RememberTokens';
+    }
+}

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Models;
+
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -91,7 +92,10 @@ class Role extends Model
      * @param  string|null                                                              $search  Search term.
      * @return \Illuminate\Database\Eloquent\Builder<\Equidna\SwiftAuth\Models\Role>          Filtered query.
      */
-    public function scopeSearch(Builder $query, null|string $search): Builder
+    public function scopeSearch(
+        Builder $query,
+        null|string $search,
+    ): Builder
     {
         if (empty($search)) {
             return $query;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Models;
+
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -70,6 +71,8 @@ class User extends Authenticatable
     ];
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'locked_until' => 'datetime',
+        'last_failed_login_at' => 'datetime',
     ];
 
     /**
@@ -148,7 +151,10 @@ class User extends Authenticatable
      * @param  string|null                                                               $search  Search term.
      * @return \Illuminate\Database\Eloquent\Builder<\Equidna\SwiftAuth\Models\User>          Filtered query.
      */
-    public function scopeSearch(Builder $query, null|string $search): Builder
+    public function scopeSearch(
+        Builder $query,
+        null|string $search,
+    ): Builder
     {
         if (empty($search)) {
             return $query;

--- a/src/Models/UserSession.php
+++ b/src/Models/UserSession.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Tracks active SwiftAuth user sessions.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Models
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://github.com/EquidnaMX/swift_auth
+ */
+
+namespace Equidna\SwiftAuth\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Represents a persisted session for a SwiftAuth user.
+ *
+ * @property int    $id_session
+ * @property int    $id_user
+ * @property string $session_id
+ * @property string $ip_address
+ * @property string $user_agent
+ * @property string $device_name
+ * @property string $platform
+ * @property string $browser
+ * @property \Illuminate\Support\Carbon $last_activity
+ */
+class UserSession extends Model
+{
+    protected $table;
+    protected $primaryKey = 'id_session';
+
+    protected $fillable = [
+        'id_user',
+        'session_id',
+        'ip_address',
+        'user_agent',
+        'device_name',
+        'platform',
+        'browser',
+        'last_activity',
+    ];
+
+    protected $casts = [
+        'last_activity' => 'datetime',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        try {
+            $prefix = config('swift-auth.table_prefix', '');
+        } catch (\Throwable $exception) {
+            $prefix = '';
+        }
+
+        $this->table = $prefix . 'Sessions';
+    }
+}

--- a/src/Providers/RateLimitServiceProvider.php
+++ b/src/Providers/RateLimitServiceProvider.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Providers;
+
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -37,7 +38,10 @@ final class RateLimitServiceProvider extends ServiceProvider
                 return Limit::perMinute(5)
                     ->by($request->ip())
                     ->response(
-                        function (Request $request, array $headers) {
+                        function (
+                            Request $request,
+                            array $headers,
+                        ) {
                             return response()->json(
                                 ['message' => 'Too many registration attempts. Please try again later.'],
                                 429,
@@ -57,7 +61,10 @@ final class RateLimitServiceProvider extends ServiceProvider
                 return Limit::perMinutes($decaySeconds / 60, $attempts)
                     ->by($request->input('email', $request->ip()))
                     ->response(
-                        function (Request $request, array $headers) {
+                        function (
+                            Request $request,
+                            array $headers,
+                        ) {
                             return response()->json(
                                 ['message' => 'Too many password reset requests. Please wait before trying again.'],
                                 429,
@@ -77,7 +84,10 @@ final class RateLimitServiceProvider extends ServiceProvider
                 return Limit::perMinutes($decaySeconds / 60, $attempts)
                     ->by($request->input('email', $request->ip()))
                     ->response(
-                        function (Request $request, array $headers) {
+                        function (
+                            Request $request,
+                            array $headers,
+                        ) {
                             return response()->json(
                                 ['message' => 'Too many email verification requests. Please check your inbox or try again later.'],
                                 429,

--- a/src/Providers/SwiftAuthServiceProvider.php
+++ b/src/Providers/SwiftAuthServiceProvider.php
@@ -12,12 +12,17 @@
  */
 
 namespace Equidna\SwiftAuth\Providers;
+
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 
 use Equidna\SwiftAuth\Console\Commands\CreateAdminUser;
 use Equidna\SwiftAuth\Console\Commands\InstallSwiftAuth;
+use Equidna\SwiftAuth\Console\Commands\ListSessions;
 use Equidna\SwiftAuth\Console\Commands\PreviewEmailTemplates;
+use Equidna\SwiftAuth\Console\Commands\PurgeExpiredTokens;
+use Equidna\SwiftAuth\Console\Commands\PurgeStaleSessions;
+use Equidna\SwiftAuth\Console\Commands\RevokeUserSessions;
 use Equidna\SwiftAuth\Console\Commands\UnlockUserCommand;
 use Equidna\SwiftAuth\Contracts\UserRepositoryInterface;
 use Equidna\SwiftAuth\Http\Middleware\CanPerformAction;
@@ -123,11 +128,34 @@ final class SwiftAuthServiceProvider extends ServiceProvider
         // Register Artisan commands
         if ($this->app->runningInConsole()) {
             $this->commands([
-                InstallSwiftAuth::class,
                 CreateAdminUser::class,
-                UnlockUserCommand::class,
+                InstallSwiftAuth::class,
+                ListSessions::class,
                 PreviewEmailTemplates::class,
+                PurgeExpiredTokens::class,
+                PurgeStaleSessions::class,
+                RevokeUserSessions::class,
+                UnlockUserCommand::class,
             ]);
+
+            $this->callAfterResolving(
+                \Illuminate\Console\Scheduling\Schedule::class,
+                function (\Illuminate\Console\Scheduling\Schedule $schedule): void {
+                    $schedule->command(PurgeExpiredTokens::class)->hourly();
+
+                    if (config('swift-auth.session_cleanup.enabled', true)) {
+                        $frequency = (string) config('swift-auth.session_cleanup.schedule', 'daily');
+
+                        $event = $schedule->command(PurgeStaleSessions::class);
+
+                        if (method_exists($event, $frequency)) {
+                            $event->{$frequency}();
+                        } else {
+                            $event->cron($frequency);
+                        }
+                    }
+                }
+            );
         }
     }
 

--- a/src/Repositories/EloquentUserRepository.php
+++ b/src/Repositories/EloquentUserRepository.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Repositories;
+
 use Carbon\CarbonInterval;
 
 use Equidna\SwiftAuth\Contracts\UserRepositoryInterface;
@@ -86,7 +87,10 @@ final class EloquentUserRepository implements UserRepositoryInterface
      * @param  int  $seconds  Lockout duration in seconds.
      * @return void
      */
-    public function lockAccount(User $user, int $seconds): void
+    public function lockAccount(
+        User $user,
+        int $seconds,
+    ): void
     {
         $user->locked_until = now()->add(CarbonInterval::seconds($seconds));
         $user->save();

--- a/src/Services/PasswordPolicy.php
+++ b/src/Services/PasswordPolicy.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Builds password validation rules from swift-auth configuration.
+ *
+ * PHP 8.2+
+ *
+ * @package   Equidna\SwiftAuth\Services
+ * @author    Gabriel Ruelas <gruelas@gruelas.com>
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Equidna\SwiftAuth\Services;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Generates reusable password validation rules honoring configured requirements.
+ */
+final class PasswordPolicy
+{
+    /**
+     * Returns password validation rules based on configuration.
+     *
+     * @return array<int, \Illuminate\Validation\Rules\Password|\Illuminate\Validation\Rules\In>
+     */
+    public static function rules(): array
+    {
+        $minLength = (int) config('swift-auth.password_min_length', 8);
+        /** @var array{require_letters?:bool,require_mixed_case?:bool,require_numbers?:bool,require_symbols?:bool,disallow_common_passwords?:bool,common_passwords?:array<int,string>}|null $requirements */
+        $requirements = config('swift-auth.password_requirements', []);
+
+        $rule = Password::min($minLength);
+
+        if ($requirements['require_letters'] ?? false) {
+            $rule->letters();
+        }
+
+        if ($requirements['require_mixed_case'] ?? false) {
+            $rule->mixedCase();
+        }
+
+        if ($requirements['require_numbers'] ?? false) {
+            $rule->numbers();
+        }
+
+        if ($requirements['require_symbols'] ?? false) {
+            $rule->symbols();
+        }
+
+        $rules = [$rule];
+
+        if ($requirements['disallow_common_passwords'] ?? false) {
+            $common = $requirements['common_passwords'] ?? [];
+            if (is_array($common) && $common !== []) {
+                $rules[] = Rule::notIn($common);
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/src/Services/SwiftSessionAuth.php
+++ b/src/Services/SwiftSessionAuth.php
@@ -12,11 +12,18 @@
  */
 
 namespace Equidna\SwiftAuth\Services;
+
+use Illuminate\Support\Facades\Cookie;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Session\Store as Session;
+use Illuminate\Support\Str;
+
+use Carbon\CarbonImmutable;
 
 use Equidna\SwiftAuth\Contracts\UserRepositoryInterface;
+use Equidna\SwiftAuth\Models\RememberToken;
 use Equidna\SwiftAuth\Models\User;
+use Equidna\SwiftAuth\Models\UserSession;
 
 /**
  * Provides session-based authentication handling for users.
@@ -27,6 +34,14 @@ class SwiftSessionAuth
 {
     protected Session $session;
     protected string $sessionKey = 'swift_auth_user_id';
+    protected string $sessionUidKey = 'swift_auth_session_id';
+    protected string $createdAtKey = 'swift_auth_created_at';
+    protected string $lastActivityKey = 'swift_auth_last_activity';
+    protected string $absoluteExpiryKey = 'swift_auth_absolute_expires_at';
+    protected string $rememberCookieName;
+    protected string $pendingMfaUserKey = 'swift_auth_pending_mfa_user_id';
+    protected string $pendingMfaDriverKey = 'swift_auth_pending_mfa_driver';
+    private null|User $cachedUser = null;
 
     /**
      * Creates a new SwiftSessionAuth instance.
@@ -39,17 +54,77 @@ class SwiftSessionAuth
         private UserRepositoryInterface $userRepository
     ) {
         $this->session = $session;
+        $this->rememberCookieName = (string) $this->getConfig(
+            'swift-auth.remember_me.cookie_name',
+            'swift_auth_remember',
+        );
     }
 
     /**
      * Logs in a user by storing their ID in the session.
      *
      * @param  User $user  User instance to authenticate.
-     * @return void
+     * @return array{evicted_session_ids: array<int, string>}
      */
-    public function login(User $user): void
-    {
+    public function login(
+        User $user,
+        null|string $ipAddress = null,
+        null|string $userAgent = null,
+        null|string $deviceName = null,
+        bool $remember = false,
+    ): array {
+        $this->session->regenerate(true);
+
+        $this->cachedUser = $user;
+
+        $now = CarbonImmutable::now();
+        $sessionId = $this->session->getId();
+        $absoluteExpiry = $this->getAbsoluteExpiry($now);
+
+        $this->session->forget($this->pendingMfaUserKey);
+        $this->session->forget($this->pendingMfaDriverKey);
+
         $this->session->put($this->sessionKey, $user->getKey());
+        $this->session->put($this->sessionUidKey, $sessionId);
+        $this->session->put($this->createdAtKey, $now->toIso8601String());
+        $this->session->put($this->lastActivityKey, $now->toIso8601String());
+
+        if ($absoluteExpiry !== null) {
+            $this->session->put($this->absoluteExpiryKey, $absoluteExpiry->toIso8601String());
+        }
+
+        $metadata = $this->extractAgentMetadata($userAgent);
+
+        $this->recordUserSession(
+            user: $user,
+            sessionId: $sessionId,
+            ipAddress: $ipAddress,
+            userAgent: $userAgent,
+            deviceName: $deviceName,
+            platform: $metadata['platform'],
+            browser: $metadata['browser'],
+            lastActivity: $now,
+        );
+
+        $evicted = $this->enforceSessionLimit(
+            user: $user,
+            currentSessionId: $sessionId,
+        );
+
+        if ($remember && $this->shouldIssueRememberToken()) {
+            $this->queueRememberToken(
+                user: $user,
+                ipAddress: $ipAddress,
+                userAgent: $userAgent,
+                deviceName: $deviceName,
+                platform: $metadata['platform'],
+                browser: $metadata['browser'],
+            );
+        }
+
+        return [
+            'evicted_session_ids' => $evicted,
+        ];
     }
 
     /**
@@ -59,7 +134,57 @@ class SwiftSessionAuth
      */
     public function logout(): void
     {
+        $sessionId = $this->session->get($this->sessionUidKey);
+        $rememberValue = Cookie::get($this->rememberCookieName);
+
+        $this->cachedUser = null;
+
         $this->session->forget($this->sessionKey);
+        $this->session->forget($this->sessionUidKey);
+        $this->session->forget($this->createdAtKey);
+        $this->session->forget($this->lastActivityKey);
+        $this->session->forget($this->absoluteExpiryKey);
+        $this->session->forget($this->pendingMfaUserKey);
+        $this->session->forget($this->pendingMfaDriverKey);
+
+        if ($sessionId) {
+            $this->deleteUserSession($sessionId);
+        }
+
+        if (is_string($rememberValue)) {
+            $this->deleteRememberToken($rememberValue);
+        }
+
+        $this->forgetRememberCookie();
+
+        $this->session->invalidate();
+        $this->session->regenerate(true);
+    }
+
+    /**
+     * Records a pending MFA challenge without completing login.
+     *
+     * @param  User        $user       Authenticated user awaiting MFA.
+     * @param  string      $driver     MFA driver identifier (otp/webauthn).
+     * @param  null|string $ipAddress  Request IP address.
+     * @param  null|string $userAgent  Request user agent string.
+     * @return void
+     */
+    public function startMfaChallenge(
+        User $user,
+        string $driver,
+        null|string $ipAddress = null,
+        null|string $userAgent = null,
+    ): void {
+        $this->session->put($this->pendingMfaUserKey, $user->getKey());
+        $this->session->put($this->pendingMfaDriverKey, $driver);
+
+        logger()->info('swift-auth.mfa.challenge_started', [
+            'user_id' => $user->getKey(),
+            'driver' => $driver,
+            'ip' => $ipAddress,
+            'user_agent' => $userAgent,
+        ]);
     }
 
     /**
@@ -69,7 +194,47 @@ class SwiftSessionAuth
      */
     public function check(): bool
     {
-        return $this->session->has($this->sessionKey);
+        $this->cachedUser = null;
+
+        $id = $this->id();
+
+        if (!$id && !$this->attemptRememberLogin()) {
+            return false;
+        }
+
+        $userId = $this->id();
+        $sessionId = (string) $this->session->get($this->sessionUidKey);
+
+        if ($sessionId === '' || !$this->sessionRecordExists($sessionId)) {
+            $this->logout();
+
+            return false;
+        }
+
+        if (!$userId) {
+            $this->logout();
+
+            return false;
+        }
+
+        $user = $this->userRepository->findById($userId);
+
+        if (!$user) {
+            $this->logout();
+
+            return false;
+        }
+
+        if ($this->isExpired()) {
+            $this->logout();
+
+            return false;
+        }
+
+        $this->cachedUser = $user;
+        $this->touchLastActivity();
+
+        return true;
     }
 
     /**
@@ -89,8 +254,11 @@ class SwiftSessionAuth
      */
     public function user(): null|User
     {
-        $id = $this->id();
-        return $id ? $this->userRepository->findById($id) : null;
+        if (!$this->check()) {
+            return null;
+        }
+
+        return $this->cachedUser;
     }
 
     /**
@@ -104,10 +272,678 @@ class SwiftSessionAuth
         $id = $this->id();
 
         if (!$id || !($user = $this->userRepository->findById($id))) {
-            throw new ModelNotFoundException("User not found");
+            throw new ModelNotFoundException('User not found');
         }
 
         return $user;
+    }
+
+    /**
+     * Returns all tracked sessions for the given user.
+     *
+     * @param  int $userId  Identifier of the user to inspect.
+     * @return \Illuminate\Support\Collection<int, UserSession>
+     */
+    public function sessionsForUser(int $userId): \Illuminate\Support\Collection
+    {
+        return UserSession::query()
+            ->where('id_user', $userId)
+            ->orderByDesc('last_activity')
+            ->get();
+    }
+
+    /**
+     * Returns all tracked sessions across all users.
+     *
+     * @return \Illuminate\Support\Collection<int, UserSession>
+     */
+    public function allSessions(): \Illuminate\Support\Collection
+    {
+        return UserSession::query()
+            ->orderByDesc('last_activity')
+            ->get();
+    }
+
+    /**
+     * Revokes a specific session owned by the given user.
+     *
+     * @param  int    $userId     Identifier of the user who owns the session.
+     * @param  string $sessionId  Session identifier to revoke.
+     * @return void
+     */
+    public function revokeSession(
+        int $userId,
+        string $sessionId,
+    ): void {
+        UserSession::query()
+            ->where('id_user', $userId)
+            ->where('session_id', $sessionId)
+            ->delete();
+
+        if ($this->session->getId() === $sessionId) {
+            $this->logout();
+        }
+    }
+
+    /**
+     * Revokes all sessions for a given user, optionally clearing remember-me tokens.
+     *
+     * @param  int  $userId                 Identifier of the user whose sessions will be removed.
+     * @param  bool $includeRememberTokens  Whether to also delete remember-me tokens for the user.
+     * @return array{deleted_sessions:int, cleared_remember_tokens:int}
+     */
+    public function revokeAllSessionsForUser(
+        int $userId,
+        bool $includeRememberTokens = false,
+    ): array {
+        $deleted = UserSession::query()
+            ->where('id_user', $userId)
+            ->delete();
+
+        $activeSessionUserId = (int) $this->session->get($this->sessionKey);
+
+        if ($activeSessionUserId === $userId) {
+            $this->logout();
+        }
+
+        $clearedRememberTokens = $includeRememberTokens
+            ? $this->revokeRememberTokensForUser($userId)
+            : 0;
+
+        return [
+            'deleted_sessions' => $deleted,
+            'cleared_remember_tokens' => $clearedRememberTokens,
+        ];
+    }
+
+    /**
+     * Deletes all remember-me tokens for the given user.
+     *
+     * @param  int $userId  Identifier of the user whose tokens will be deleted.
+     * @return int          Count of deleted tokens.
+     */
+    public function revokeRememberTokensForUser(int $userId): int
+    {
+        return RememberToken::query()
+            ->where('id_user', $userId)
+            ->delete();
+    }
+
+    /**
+     * Determines whether the current session has exceeded idle or absolute limits.
+     *
+     * @return bool
+     */
+    private function isExpired(): bool
+    {
+        $now = CarbonImmutable::now();
+        $lastActivity = $this->parseTimestamp((string) $this->session->get($this->lastActivityKey));
+
+        $idleTimeout = $this->getConfig(
+            'swift-auth.session_lifetimes.idle_timeout_seconds',
+            null
+        );
+
+        if ($idleTimeout && $lastActivity && $now->diffInSeconds($lastActivity) > $idleTimeout) {
+            return true;
+        }
+
+        $absoluteExpiry = $this->parseTimestamp((string) $this->session->get($this->absoluteExpiryKey));
+
+        return $absoluteExpiry !== null && $now->greaterThan($absoluteExpiry);
+    }
+
+    /**
+     * Validates that the current session exists in the persistence store.
+     *
+     * @param  string $sessionId  Identifier to verify.
+     * @return bool
+     */
+    private function sessionRecordExists(string $sessionId): bool
+    {
+        try {
+            return UserSession::query()
+                ->where('session_id', $sessionId)
+                ->exists();
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.session.validation_failed', [
+                'session_id' => $sessionId,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Updates the last-activity timestamp for the current session.
+     *
+     * @return void
+     */
+    private function touchLastActivity(): void
+    {
+        $now = CarbonImmutable::now();
+        $sessionId = (string) $this->session->get($this->sessionUidKey);
+
+        $this->session->put($this->lastActivityKey, $now->toIso8601String());
+
+        try {
+            if ($sessionId) {
+                UserSession::query()
+                    ->where('session_id', $sessionId)
+                    ->update([
+                        'last_activity' => $now,
+                    ]);
+            }
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.session.touch_failed', [
+                'session_id' => $sessionId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Computes the absolute expiration timestamp for a session.
+     *
+     * @param  CarbonImmutable $now  The moment the session was issued.
+     * @return CarbonImmutable|null
+     */
+    private function getAbsoluteExpiry(CarbonImmutable $now): null|CarbonImmutable
+    {
+        $absoluteTtl = $this->getConfig(
+            'swift-auth.session_lifetimes.absolute_timeout_seconds',
+            null
+        );
+
+        return $absoluteTtl ? $now->addSeconds($absoluteTtl) : null;
+    }
+
+    /**
+     * Attempts to authenticate using a persistent remember-me cookie.
+     *
+     * @return bool
+     */
+    private function attemptRememberLogin(): bool
+    {
+        if (!$this->shouldIssueRememberToken()) {
+            return false;
+        }
+
+        $cookie = Cookie::get($this->rememberCookieName);
+
+        if (!is_string($cookie) || $cookie === '') {
+            return false;
+        }
+
+        [$selector, $validator] = $this->splitRememberCookie($cookie);
+
+        if ($selector === null || $validator === null) {
+            $this->forgetRememberCookie();
+
+            return false;
+        }
+
+        try {
+            $token = RememberToken::query()
+                ->where('selector', $selector)
+                ->first();
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.remember.load_failed', [
+                'selector' => $selector,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return false;
+        }
+
+        if (!$token || $this->rememberTokenExpired($token)) {
+            $token?->delete();
+            $this->forgetRememberCookie();
+
+            return false;
+        }
+
+        $expected = hash('sha256', $validator);
+
+        if (!hash_equals($token->hashed_token, $expected)) {
+            $token->delete();
+            $this->forgetRememberCookie();
+
+            return false;
+        }
+
+        $user = $this->userRepository->findById((int) $token->id_user);
+
+        if (!$user) {
+            $token->delete();
+            $this->forgetRememberCookie();
+
+            return false;
+        }
+
+        $shouldRotate = (bool) $this->getConfig(
+            'swift-auth.remember_me.rotate_on_use',
+            true,
+        );
+
+        if ($shouldRotate) {
+            $token->delete();
+        } else {
+            $token->last_used_at = CarbonImmutable::now();
+            $token->save();
+        }
+
+        $request = request();
+        $ip = method_exists($request, 'ip') ? $request->ip() : null;
+        $userAgent = method_exists($request, 'userAgent') ? $request->userAgent() : null;
+
+        $this->login(
+            user: $user,
+            ipAddress: $ip,
+            userAgent: $userAgent,
+            deviceName: $this->resolveDeviceNameFromRequest(),
+            remember: $shouldRotate,
+        );
+
+        return true;
+    }
+
+    /**
+     * Persists a remember-me token and queues the cookie on the response.
+     *
+     * @param  User        $user        Authenticated user.
+     * @param  null|string $ipAddress   Request IP address.
+     * @param  null|string $userAgent   Request user agent string.
+     * @param  null|string $deviceName  Device name.
+     * @param  null|string $platform    Parsed platform name.
+     * @param  null|string $browser     Parsed browser name.
+     * @return void
+     */
+    private function queueRememberToken(
+        User $user,
+        null|string $ipAddress,
+        null|string $userAgent,
+        null|string $deviceName,
+        null|string $platform,
+        null|string $browser,
+    ): void {
+        try {
+            $selector = Str::random(20);
+            $validator = Str::random(64);
+            $hashedValidator = hash('sha256', $validator);
+            $expiresAt = CarbonImmutable::now()->addSeconds(
+                (int) $this->getConfig('swift-auth.remember_me.ttl_seconds', 1209600),
+            );
+
+            RememberToken::query()->create(
+                [
+                    'id_user' => $user->getKey(),
+                    'selector' => $selector,
+                    'hashed_token' => $hashedValidator,
+                    'expires_at' => $expiresAt,
+                    'ip_address' => $ipAddress,
+                    'user_agent' => $userAgent,
+                    'device_name' => $deviceName,
+                    'platform' => $platform,
+                    'browser' => $browser,
+                ],
+            );
+
+            $cookieValue = $selector . ':' . $validator;
+            $minutes = (int) ceil(
+                (int) $this->getConfig('swift-auth.remember_me.ttl_seconds', 1209600) / 60,
+            );
+
+            $cookie = Cookie::make(
+                $this->rememberCookieName,
+                $cookieValue,
+                minutes: $minutes,
+                path: (string) $this->getConfig('swift-auth.remember_me.path', '/'),
+                domain: $this->getConfig('swift-auth.remember_me.domain', null),
+                secure: (bool) $this->getConfig('swift-auth.remember_me.secure', true),
+                httpOnly: true,
+                raw: false,
+                sameSite: (string) $this->getConfig('swift-auth.remember_me.same_site', 'lax'),
+            );
+
+            Cookie::queue($cookie);
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.remember.issue_failed', [
+                'user_id' => $user->getKey(),
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Deletes a remember-me token associated with the given cookie value.
+     *
+     * @param  string $cookieValue  Raw cookie value containing selector and validator.
+     * @return void
+     */
+    private function deleteRememberToken(string $cookieValue): void
+    {
+        [$selector, $validator] = $this->splitRememberCookie($cookieValue);
+
+        if ($selector === null || $validator === null) {
+            $this->forgetRememberCookie();
+
+            return;
+        }
+
+        try {
+            RememberToken::query()
+                ->where('selector', $selector)
+                ->delete();
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.remember.delete_failed', [
+                'selector' => $selector,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
+        $this->forgetRememberCookie();
+    }
+
+    /**
+     * Removes the remember-me cookie from the response queue.
+     *
+     * @return void
+     */
+    private function forgetRememberCookie(): void
+    {
+        Cookie::queue(Cookie::forget($this->rememberCookieName));
+    }
+
+    /**
+     * Checks if remember-me functionality is enabled.
+     *
+     * @return bool
+     */
+    private function shouldIssueRememberToken(): bool
+    {
+        return (bool) $this->getConfig('swift-auth.remember_me.enabled', true);
+    }
+
+    /**
+     * Determines whether the given remember token has expired.
+     *
+     * @param  RememberToken $token  Token to check.
+     * @return bool
+     */
+    private function rememberTokenExpired(RememberToken $token): bool
+    {
+        return $token->expires_at !== null
+            && CarbonImmutable::now()->greaterThan(CarbonImmutable::parse($token->expires_at));
+    }
+
+    /**
+     * Extracts selector and validator segments from a cookie value.
+     *
+     * @param  string $cookieValue  Raw cookie value.
+     * @return array{0:null|string,1:null|string}
+     */
+    private function splitRememberCookie(string $cookieValue): array
+    {
+        $parts = explode(':', $cookieValue, 2);
+
+        if (count($parts) !== 2 || $parts[0] === '' || $parts[1] === '') {
+            return [null, null];
+        }
+
+        return [$parts[0], $parts[1]];
+    }
+
+    /**
+     * Derives a device name from the current request if available.
+     *
+     * @return string|null
+     */
+    private function resolveDeviceNameFromRequest(): null|string
+    {
+        try {
+            $request = request();
+
+            return method_exists($request, 'header')
+                ? (string) $request->header('X-Device-Name', '')
+                : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts coarse device metadata from a user agent string.
+     *
+     * @param  null|string $userAgent  Raw user agent string.
+     * @return array{platform:null|string,browser:null|string}
+     */
+    private function extractAgentMetadata(null|string $userAgent): array
+    {
+        if (!$userAgent) {
+            return [
+                'platform' => null,
+                'browser' => null,
+            ];
+        }
+
+        $platform = null;
+        $browser = null;
+
+        $knownPlatforms = [
+            'Windows' => '/windows/i',
+            'macOS' => '/macintosh|mac os x/i',
+            'iOS' => '/iphone|ipad|ipod/i',
+            'Android' => '/android/i',
+            'Linux' => '/linux/i',
+        ];
+
+        foreach ($knownPlatforms as $name => $pattern) {
+            if (preg_match($pattern, $userAgent)) {
+                $platform = $name;
+
+                break;
+            }
+        }
+
+        $knownBrowsers = [
+            'Chrome' => '/chrome|crios/i',
+            'Firefox' => '/firefox|fennec/i',
+            'Safari' => '/safari/i',
+            'Edge' => '/edg/i',
+            'Opera' => '/opera|opr\//i',
+        ];
+
+        foreach ($knownBrowsers as $name => $pattern) {
+            if (preg_match($pattern, $userAgent)) {
+                $browser = $name;
+
+                break;
+            }
+        }
+
+        return [
+            'platform' => $platform,
+            'browser' => $browser,
+        ];
+    }
+
+    /**
+     * Records a session row for the authenticated user.
+     *
+     * @param  User             $user          The authenticated user.
+     * @param  string           $sessionId     Unique session identifier.
+     * @param  null|string      $ipAddress     Request IP address.
+     * @param  null|string      $userAgent     Request user agent string.
+     * @param  null|string      $deviceName    Device name hint.
+     * @param  CarbonImmutable  $lastActivity  Timestamp of last activity.
+     * @return void
+     */
+    private function recordUserSession(
+        User $user,
+        string $sessionId,
+        null|string $ipAddress,
+        null|string $userAgent,
+        null|string $deviceName,
+        null|string $platform,
+        null|string $browser,
+        CarbonImmutable $lastActivity,
+    ): void {
+        try {
+            UserSession::updateOrCreate(
+                [
+                    'session_id' => $sessionId,
+                ],
+                [
+                    'id_user' => $user->getKey(),
+                    'ip_address' => $ipAddress,
+                    'user_agent' => $userAgent,
+                    'device_name' => $deviceName,
+                    'platform' => $platform,
+                    'browser' => $browser,
+                    'last_activity' => $lastActivity,
+                ],
+            );
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.session.record_failed', [
+                'session_id' => $sessionId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Enforces a per-user session limit by evicting old or new sessions.
+     *
+     * @param  User   $user              Authenticated user.
+     * @param  string $currentSessionId  Newly issued session identifier.
+     * @return array<int, string>
+     */
+    private function enforceSessionLimit(
+        User $user,
+        string $currentSessionId,
+    ): array {
+        $maxSessions = $this->getConfig(
+            'swift-auth.session_limits.max_sessions',
+            null,
+        );
+
+        if ($maxSessions === null) {
+            return [];
+        }
+
+        $maxSessions = (int) $maxSessions;
+
+        if ($maxSessions <= 0) {
+            return [];
+        }
+
+        $policy = (string) $this->getConfig(
+            'swift-auth.session_limits.eviction',
+            'oldest',
+        );
+
+        try {
+            $sessions = UserSession::query()
+                ->where('id_user', $user->getKey())
+                ->orderByDesc('last_activity')
+                ->get();
+
+            if ($sessions->count() <= $maxSessions) {
+                return [];
+            }
+
+            $overflow = $sessions->count() - $maxSessions;
+
+            $sessionsToDelete = $policy === 'newest'
+                ? $sessions->take($overflow)
+                : $sessions->slice($maxSessions, $overflow);
+
+            $sessionIds = $sessionsToDelete
+                ->pluck('session_id')
+                ->all();
+
+            UserSession::query()
+                ->whereIn('session_id', $sessionIds)
+                ->delete();
+
+            if (in_array($currentSessionId, $sessionIds, true)) {
+                $this->logout();
+            }
+
+            logger()->info('swift-auth.session.evicted', [
+                'user_id' => $user->getKey(),
+                'evicted_sessions' => $sessionIds,
+                'policy' => $policy,
+            ]);
+
+            return $sessionIds;
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.session.limit_enforce_failed', [
+                'user_id' => $user->getKey(),
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * Deletes a persisted session record when logging out.
+     *
+     * @param  string $sessionId  Identifier to remove.
+     * @return void
+     */
+    private function deleteUserSession(string $sessionId): void
+    {
+        try {
+            UserSession::query()
+                ->where('session_id', $sessionId)
+                ->delete();
+        } catch (\Throwable $exception) {
+            logger()->warning('swift-auth.session.delete_failed', [
+                'session_id' => $sessionId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Parses a stored timestamp string into a Carbon instance.
+     *
+     * @param  string $timestamp  Serialized timestamp from the session store.
+     * @return CarbonImmutable|null
+     */
+    private function parseTimestamp(string $timestamp): null|CarbonImmutable
+    {
+        if ($timestamp === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($timestamp);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves a configuration value with a default fallback when configuration helpers are unavailable.
+     *
+     * @param  string $key      Configuration path.
+     * @param  mixed  $default  Default fallback.
+     * @return mixed
+     */
+    private function getConfig(
+        string $key,
+        mixed $default,
+    ): mixed {
+        try {
+            return config($key, $default);
+        } catch (\Throwable) {
+            return $default;
+        }
     }
 
     /**

--- a/src/Traits/SelectiveRender.php
+++ b/src/Traits/SelectiveRender.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Traits;
+
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Config;
 
@@ -36,7 +37,11 @@ trait SelectiveRender
      * @param  array<string,mixed> $data              Additional data to pass to the view or component.
      * @return View|Response                          Rendered Blade view or Inertia component.
      */
-    protected function render(string $bladeView, string $inertiaComponent, array $data = []): View|Response
+    protected function render(
+        string $bladeView,
+        string $inertiaComponent,
+        array $data = [],
+    ): View|Response
     {
         $flashMessages = [
             'success' => session('success'),

--- a/src/config/swift-auth.php
+++ b/src/config/swift-auth.php
@@ -44,6 +44,98 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Login Rate Limits
+    |--------------------------------------------------------------------------
+    |
+    | Tune rate limits for login attempts by email and IP. Each limiter
+    | contains the allowed attempts within a decay window (seconds).
+    |
+    */
+
+    'login_rate_limits' => [
+        'email' => [
+            'attempts' => 5,
+            'decay_seconds' => 300,
+        ],
+        'ip' => [
+            'attempts' => 20,
+            'decay_seconds' => 300,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Lifetimes
+    |--------------------------------------------------------------------------
+    |
+    | Controls how long sessions remain valid. The idle timeout resets whenever
+    | activity occurs, while the absolute timeout caps the total lifespan from
+    | the moment of login. Set values to null to disable either limit.
+    |
+    */
+
+    'session_lifetimes' => [
+        'idle_timeout_seconds' => env('SWIFT_AUTH_SESSION_IDLE_TIMEOUT', 1800), // 30 minutes
+        'absolute_timeout_seconds' => env('SWIFT_AUTH_SESSION_ABSOLUTE_TIMEOUT', 86400), // 24 hours
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remember Me Tokens
+    |--------------------------------------------------------------------------
+    |
+    | Controls persistent login tokens stored as signed cookies. When enabled,
+    | users can opt into a long-lived cookie that is rotated on use and
+    | revocable server-side. Cookie attributes may be tuned for your deployment.
+    |
+    */
+
+    'remember_me' => [
+        'enabled' => env('SWIFT_AUTH_REMEMBER_ENABLED', true),
+        'cookie_name' => env('SWIFT_AUTH_REMEMBER_COOKIE', 'swift_auth_remember'),
+        'ttl_seconds' => env('SWIFT_AUTH_REMEMBER_TTL', 1209600), // 14 days
+        'rotate_on_use' => env('SWIFT_AUTH_REMEMBER_ROTATE', true),
+        'secure' => env('SWIFT_AUTH_REMEMBER_SECURE', true),
+        'same_site' => env('SWIFT_AUTH_REMEMBER_SAMESITE', 'lax'),
+        'domain' => env('SWIFT_AUTH_REMEMBER_DOMAIN', null),
+        'path' => env('SWIFT_AUTH_REMEMBER_PATH', '/'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session Cleanup
+    |--------------------------------------------------------------------------
+    |
+    | Automated cleanup of stale session rows in the persistence table. The
+    | cutoff defaults to the longest configured session lifetime; adjust the
+    | grace period to keep limited historical data if desired.
+    |
+    */
+
+    'session_cleanup' => [
+        'enabled' => env('SWIFT_AUTH_SESSION_CLEANUP_ENABLED', true),
+        'grace_seconds' => env('SWIFT_AUTH_SESSION_CLEANUP_GRACE', 0),
+        'schedule' => env('SWIFT_AUTH_SESSION_CLEANUP_CRON', 'daily'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Concurrent Session Limits
+    |--------------------------------------------------------------------------
+    |
+    | Caps the number of simultaneous sessions per user. When the limit is
+    | exceeded, SwiftAuth will evict either the oldest or newest sessions based
+    | on the eviction policy. Set `max_sessions` to null to disable.
+    |
+    */
+
+    'session_limits' => [
+        'max_sessions' => env('SWIFT_AUTH_MAX_SESSIONS', null),
+        'eviction' => env('SWIFT_AUTH_SESSION_EVICTION', 'oldest'), // oldest | newest
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Password Reset Token TTL
     |--------------------------------------------------------------------------
     |
@@ -89,6 +181,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Multi-factor Authentication (OTP/WebAuthn)
+    |--------------------------------------------------------------------------
+    |
+    | Enable this to require a second factor after primary credential
+    | verification. The driver flag allows clients to display the correct UI
+    | (e.g., OTP code entry or WebAuthn prompt). Verification is expected to be
+    | completed by the host application using the provided verification URL.
+    |
+    */
+
+    'mfa' => [
+        'enabled' => env('SWIFT_AUTH_MFA_ENABLED', false),
+        'driver' => env('SWIFT_AUTH_MFA_DRIVER', 'otp'), // otp | webauthn
+        'verification_url' => env('SWIFT_AUTH_MFA_VERIFICATION_URL', '/mfa/verify'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Password minimum length and hashing
     |--------------------------------------------------------------------------
     |
@@ -105,6 +215,38 @@ return [
 
     'password_min_length' => 8,
     'hash_driver' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Complexity
+    |--------------------------------------------------------------------------
+    |
+    | Optional complexity requirements layered on top of the minimum length.
+    | Enable the booleans to enforce the related rule. The `common_passwords`
+    | list is only used when `disallow_common_passwords` is true.
+    |
+    */
+
+    'password_requirements' => [
+        'require_letters' => false,
+        'require_mixed_case' => false,
+        'require_numbers' => false,
+        'require_symbols' => false,
+        'disallow_common_passwords' => false,
+        'common_passwords' => [
+            'password',
+            'password1',
+            '123456',
+            '12345678',
+            '123456789',
+            'qwerty',
+            'abc123',
+            'iloveyou',
+            'welcome',
+            'admin',
+            'letmein',
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -147,6 +289,10 @@ return [
         'resend_rate_limit' => [
             'attempts' => 3,
             'decay_seconds' => 300, // 5 minutes
+        ],
+        'ip_rate_limit' => [
+            'attempts' => 5,
+            'decay_seconds' => 60, // 1 minute
         ],
     ],
 
@@ -191,5 +337,15 @@ return [
     'security_headers' => [
         'csp' => env('SWIFT_AUTH_CSP', null), // e.g., "default-src 'self'; script-src 'self' 'unsafe-inline'"
         'permissions_policy' => env('SWIFT_AUTH_PERMISSIONS_POLICY', null), // e.g., "geolocation=(), microphone=()"
+        'hsts' => [
+            'enabled' => true,
+            'max_age' => 31536000,
+            'include_subdomains' => true,
+            'preload' => false,
+        ],
+        'cross_origin_opener_policy' => env('SWIFT_AUTH_COOP', null), // e.g., "same-origin"
+        'cross_origin_embedder_policy' => env('SWIFT_AUTH_COEP', null), // e.g., "require-corp"
+        'cross_origin_resource_policy' => env('SWIFT_AUTH_CORP', null), // e.g., "same-origin"
+        'referrer_policy' => env('SWIFT_AUTH_REFERRER_POLICY', 'strict-origin-when-cross-origin'),
     ],
 ];

--- a/src/database/migrations/create_remember_tokens_table.php
+++ b/src/database/migrations/create_remember_tokens_table.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Migration: create remember tokens table for SwiftAuth.
+ *
+ * PHP 8.2+
+ *
+ * @package Equidna\SwiftAuth\Database\Migrations
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $prefix = config('swift-auth.table_prefix', 'swift-auth_');
+
+        Schema::create($prefix . 'RememberTokens', function (Blueprint $table) {
+            $table->id('id_remember_token');
+            $table->unsignedBigInteger('id_user');
+            $table->string('selector')->unique();
+            $table->string('hashed_token');
+            $table->timestamp('expires_at');
+            $table->timestamp('last_used_at')->nullable();
+            $table->string('ip_address')->nullable();
+            $table->string('user_agent', 1024)->nullable();
+            $table->string('device_name', 255)->nullable();
+            $table->string('platform', 255)->nullable();
+            $table->string('browser', 255)->nullable();
+            $table->timestamps();
+
+            $table->index(['id_user', 'expires_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $prefix = config('swift-auth.table_prefix', 'swift-auth_');
+
+        Schema::dropIfExists($prefix . 'RememberTokens');
+    }
+};

--- a/src/database/migrations/create_sessions_table.php
+++ b/src/database/migrations/create_sessions_table.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Migration: create sessions table for SwiftAuth.
+ *
+ * PHP 8.2+
+ *
+ * @package Equidna\SwiftAuth\Database\Migrations
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $prefix = config('swift-auth.table_prefix', 'swift-auth_');
+
+        Schema::create($prefix . 'Sessions', function (Blueprint $table) {
+            $table->id('id_session');
+            $table->unsignedBigInteger('id_user');
+            $table->string('session_id')->unique();
+            $table->string('ip_address')->nullable();
+            $table->string('user_agent', 1024)->nullable();
+            $table->string('device_name', 255)->nullable();
+            $table->string('platform', 255)->nullable();
+            $table->string('browser', 255)->nullable();
+            $table->timestamp('last_activity');
+            $table->timestamps();
+
+            $table->index(['id_user', 'last_activity']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $prefix = config('swift-auth.table_prefix', 'swift-auth_');
+
+        Schema::dropIfExists($prefix . 'Sessions');
+    }
+};

--- a/src/routes/swift-auth-admin-sessions.php
+++ b/src/routes/swift-auth-admin-sessions.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Admin session management routes for SwiftAuth package.
+ *
+ * PHP 8.2+
+ *
+ * @package Equidna\SwiftAuth\Routes
+ */
+
+use Illuminate\Support\Facades\Route;
+use Equidna\SwiftAuth\Http\Controllers\AdminSessionController;
+
+Route::prefix('admin/sessions')
+    ->as('admin.sessions.')
+    ->group(
+        function () {
+            Route::get('', [AdminSessionController::class, 'all'])->name('all');
+            Route::get('{userId}', [AdminSessionController::class, 'index'])->name('index');
+            Route::delete('{userId}/{sessionId}', [AdminSessionController::class, 'destroy'])->name('destroy');
+            Route::delete('{userId}', [AdminSessionController::class, 'destroyAll'])->name('destroy-all');
+        }
+    );

--- a/src/routes/swift-auth-email-verification.php
+++ b/src/routes/swift-auth-email-verification.php
@@ -14,8 +14,9 @@ use Illuminate\Support\Facades\Route;
 use Equidna\SwiftAuth\Http\Controllers\EmailVerificationController;
 
 $prefix = config('swift-auth.route_prefix', 'swift-auth');
+$namePrefix = config('swift-auth.route_prefix', 'swift-auth');
 
-Route::prefix($prefix)->name('swift-auth.')->group(function () {
+Route::prefix($prefix)->name($namePrefix . '.')->group(function () {
     Route::post('/email/send', [EmailVerificationController::class, 'send'])
         ->name('email.send');
 

--- a/src/routes/swift-auth-sessions.php
+++ b/src/routes/swift-auth-sessions.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Session management routes for SwiftAuth package.
+ *
+ * PHP 8.2+
+ *
+ * @package Equidna\SwiftAuth\Routes
+ */
+
+use Illuminate\Support\Facades\Route;
+use Equidna\SwiftAuth\Http\Controllers\SessionController;
+
+Route::prefix('sessions')
+    ->as('sessions.')
+    ->group(
+        function () {
+            Route::get('', [SessionController::class, 'index'])->name('index');
+            Route::delete('{sessionId}', [SessionController::class, 'destroy'])->name('destroy');
+        }
+    );

--- a/src/routes/swift-auth.php
+++ b/src/routes/swift-auth.php
@@ -8,11 +8,11 @@
  * @package Equidna\SwiftAuth\Routes
  */
 
-use Equidna\SwiftAuth\Http\Middleware\RequireAuthentication;
+use Illuminate\Support\Facades\Route;
+use Equidna\SwiftAuth\Http\Controllers\AuthController;
 use Equidna\SwiftAuth\Http\Controllers\PasswordController;
 use Equidna\SwiftAuth\Http\Middleware\CanPerformAction;
-use Equidna\SwiftAuth\Http\Controllers\AuthController;
-use Illuminate\Support\Facades\Route;
+use Equidna\SwiftAuth\Http\Middleware\RequireAuthentication;
 
 $routePrefix = config('swift-auth.route_prefix', 'swift-auth');
 
@@ -50,15 +50,20 @@ Route::middleware(['web', 'SwiftAuth.SecurityHeaders'])
                     }
                 );
 
-            Route::middleware(
-                [
-                    RequireAuthentication::class,
-                    CanPerformAction::class . ':sw-admin'
-                ]
-            )->group(
+            Route::middleware([
+                RequireAuthentication::class,
+            ])->group(
                 function () {
-                    require __DIR__ . '/swift-auth-users.php';
-                    require __DIR__ . '/swift-auth-roles.php';
+                    require __DIR__ . '/swift-auth-sessions.php';
+
+                    Route::middleware(CanPerformAction::class . ':sw-admin')
+                        ->group(
+                            function () {
+                                require __DIR__ . '/swift-auth-users.php';
+                                require __DIR__ . '/swift-auth-roles.php';
+                                require __DIR__ . '/swift-auth-admin-sessions.php';
+                            }
+                        );
                 }
             );
         }

--- a/tests/TestHelpers.php
+++ b/tests/TestHelpers.php
@@ -160,7 +160,10 @@ trait TestHelpers
      * @param  string $roleName Role name to check.
      * @return void
      */
-    protected function assertUserHasRole(User $user, string $roleName): void
+    protected function assertUserHasRole(
+        User $user,
+        string $roleName,
+    ): void
     {
         $this->assertTrue(
             $user->fresh(['roles'])->hasRoles($roleName),
@@ -175,7 +178,10 @@ trait TestHelpers
      * @param  string $roleName Role name to check.
      * @return void
      */
-    protected function assertUserDoesNotHaveRole(User $user, string $roleName): void
+    protected function assertUserDoesNotHaveRole(
+        User $user,
+        string $roleName,
+    ): void
     {
         $this->assertFalse(
             $user->fresh(['roles'])->hasRoles($roleName),
@@ -190,7 +196,10 @@ trait TestHelpers
      * @param  string $action Action to check (e.g., 'users.create').
      * @return void
      */
-    protected function assertUserCanPerformAction(User $user, string $action): void
+    protected function assertUserCanPerformAction(
+        User $user,
+        string $action,
+    ): void
     {
         $actions = $user->fresh(['roles'])->availableActions();
         $this->assertContains(
@@ -273,7 +282,10 @@ trait TestHelpers
      * @param  int  $attempts Number of failed attempts.
      * @return User           Updated user instance.
      */
-    protected function simulateFailedLoginAttempts(User $user, int $attempts): User
+    protected function simulateFailedLoginAttempts(
+        User $user,
+        int $attempts,
+    ): User
     {
         $user->failed_login_attempts = $attempts;
         $user->last_failed_login_at = now();

--- a/tests/Unit/Middleware/CanPerformActionTest.php
+++ b/tests/Unit/Middleware/CanPerformActionTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Middleware;
+
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/Unit/Middleware/RequireAuthenticationTest.php
+++ b/tests/Unit/Middleware/RequireAuthenticationTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Middleware;
+
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Unit/Middleware/SecurityHeadersTest.php
+++ b/tests/Unit/Middleware/SecurityHeadersTest.php
@@ -5,6 +5,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Middleware;
+
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 

--- a/tests/Unit/Models/PasswordResetTokenTest.php
+++ b/tests/Unit/Models/PasswordResetTokenTest.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Models;
+
 use PHPUnit\Framework\TestCase;
 
 use Equidna\SwiftAuth\Models\PasswordResetToken;

--- a/tests/Unit/Models/RoleTest.php
+++ b/tests/Unit/Models/RoleTest.php
@@ -11,6 +11,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Models;
+
 use PHPUnit\Framework\TestCase;
 
 use Equidna\SwiftAuth\Models\Role;

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Models;
+
 use Illuminate\Database\Eloquent\Collection;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Services/AccountLockoutServiceTest.php
+++ b/tests/Unit/Services/AccountLockoutServiceTest.php
@@ -28,7 +28,10 @@ class AccountLockoutServiceTest extends TestCase
     private function createNotificationDouble(): object
     {
         return new class {
-            public function sendAccountLockout(string $email, int $duration): ?string
+            public function sendAccountLockout(
+                string $email,
+                int $duration,
+            ): ?string
             {
                 return 'test-message-id';
             }

--- a/tests/Unit/Services/NotificationServiceTest.php
+++ b/tests/Unit/Services/NotificationServiceTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Services;
+
 use PHPUnit\Framework\TestCase;
 
 use Equidna\BirdFlock\BirdFlock;

--- a/tests/Unit/Services/SwiftSessionAuthTest.php
+++ b/tests/Unit/Services/SwiftSessionAuthTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Services;
+
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Session\Store as Session;
 

--- a/tests/Unit/Traits/SelectiveRenderTest.php
+++ b/tests/Unit/Traits/SelectiveRenderTest.php
@@ -12,6 +12,7 @@
  */
 
 namespace Equidna\SwiftAuth\Tests\Unit\Traits;
+
 use PHPUnit\Framework\TestCase;
 
 use Equidna\SwiftAuth\Traits\SelectiveRender;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,8 +6,11 @@
  */
 
 if (!function_exists('config')) {
-    function config(?string $key = null, $default = null)
-    {
+function config(
+    ?string $key = null,
+    $default = null,
+)
+{
         static $cfg = null;
         if ($cfg === null) {
             $cfg = ['swift-auth' => []];


### PR DESCRIPTION
## Summary
- add CLI commands to list SwiftAuth sessions and revoke user sessions from the terminal
- expose admin endpoints for listing all sessions and bulk revocation with optional remember-me cleanup
- extend session service to support global session queries and bulk revocation utilities registered in the provider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eead952ac8322a21dfa01420482a7)